### PR TITLE
Ruby 3 compatibility fix

### DIFF
--- a/lib/rustici_software_cloud_v2/api_client.rb
+++ b/lib/rustici_software_cloud_v2/api_client.rb
@@ -15,7 +15,7 @@ require 'json'
 require 'logger'
 require 'tempfile'
 require 'typhoeus'
-require 'uri'
+require 'addressable/uri'
 
 module RusticiSoftwareCloudV2
   class ApiClient
@@ -264,7 +264,7 @@ module RusticiSoftwareCloudV2
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      Addressable::URI.encode(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/rustici_software_cloud_v2/configuration.rb
+++ b/lib/rustici_software_cloud_v2/configuration.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.4.12
 
 =end
 
-require 'uri'
+require 'addressable/uri'
 
 module RusticiSoftwareCloudV2
   class Configuration
@@ -175,7 +175,7 @@ module RusticiSoftwareCloudV2
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      Addressable::URI.encode(url)
     end
 
     # Gets API key (with prefix if set).

--- a/rustici_software_cloud_v2.gemspec
+++ b/rustici_software_cloud_v2.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.3', '>= 2.3.0'
+  s.add_runtime_dependency 'addressable', '~> 2.7', '>= 2.7.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'
@@ -37,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'autotest-rails-pure', '~> 4.1', '>= 4.1.2'
   s.add_development_dependency 'autotest-growl', '~> 0.2', '>= 0.2.16'
   s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.12'
+
 
   s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
   s.test_files    = `find spec/*`.split("\n")


### PR DESCRIPTION
There were a couple of calls to the URI class that used deprecated methods. This PR addresses that.